### PR TITLE
비밀번호 재설정 페이지 추가

### DIFF
--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -1,0 +1,12 @@
+import ResetPasswordForm from "@/components/auth/ResetPassword/ResetPasswordForm";
+import React from "react";
+
+const ResetPassword = () => {
+	return (
+		<div className="flex justify-center items-center">
+			<ResetPasswordForm />
+		</div>
+	);
+};
+
+export default ResetPassword;

--- a/src/components/auth/LoginForm/LoginForm.tsx
+++ b/src/components/auth/LoginForm/LoginForm.tsx
@@ -69,7 +69,7 @@ const LoginForm = () => {
 				</div>
 
 				{/* 비밀번호 재설정 */}
-				<div className="flex justify-center text-sm text-white font-light">
+				<div className="flex justify-center text-sm text-gray200 font-light">
 					<Link
 						href="/reset-password"
 						className="underline hover:opacity-80 transition"

--- a/src/components/auth/ResetPassword/ResetPasswordForm.tsx
+++ b/src/components/auth/ResetPassword/ResetPasswordForm.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import React from "react";
+import TextInput from "@/components/common/Input/TextInput";
+import BaseButton from "@/components/common/Button/BaseButton";
+import useResetPasswordForm from "./useResetPasswordForm";
+import { EvenIcon } from "@/components/common/Icons";
+import Link from "next/link";
+
+const ResetPasswordForm = () => {
+	const { email, emailError, isLoading, handleEmailChange, handleSubmit } =
+		useResetPasswordForm();
+
+	return (
+		<div className="w-full max-w-[30rem] border border-white mt-16">
+			<div className="flex justify-center items-center pt-8 pb-4 gap-4">
+				<EvenIcon />
+				<h1 className="text-4xl">even ide</h1>
+			</div>
+
+			<div className="flex flex-col gap-5 px-6 sm:px-12 py-6">
+				<form onSubmit={handleSubmit} className="flex flex-col  gap-5">
+					<h1 className="text-xl text-white text-center">비밀번호 재설정</h1>
+					<h2 className="text-md text-white text-center leading-loose">
+						가입한 이메일 주소를 입력해주세요
+						<br />
+						이메일 인증 완료 후 비밀번호를 재설정할 수 있습니다.
+					</h2>
+
+					<TextInput
+						placeholder="이메일을 입력하세요"
+						value={email}
+						onChange={handleEmailChange}
+						error={emailError}
+						size="xl"
+					/>
+					<BaseButton type="submit" size="xl" isLoading={isLoading}>
+						인증 메일 전송
+					</BaseButton>
+					<div className="flex justify-center text-sm text-gray200 font-light">
+						<Link
+							href="/login"
+							className="underline hover:opacity-80 transition"
+						>
+							로그인으로 돌아가기
+						</Link>
+					</div>
+				</form>
+			</div>
+		</div>
+	);
+};
+
+export default ResetPasswordForm;

--- a/src/components/auth/ResetPassword/useResetPasswordForm.ts
+++ b/src/components/auth/ResetPassword/useResetPasswordForm.ts
@@ -1,0 +1,51 @@
+import { validateEmail } from "@/utils/validate";
+import { ChangeEvent, FormEvent, useCallback, useState } from "react";
+
+const useResetPasswordForm = () => {
+	const [email, setEmail] = useState("");
+	const [emailError, setEmailError] = useState("");
+	const [isLoading, setIsLoading] = useState(false);
+
+	const validateForm = useCallback(() => {
+		const error = validateEmail(email);
+		if (error) {
+			setEmailError(error);
+			return false;
+		}
+		setEmailError("");
+		return true;
+	}, [email]);
+
+	const handleEmailChange = useCallback(
+		(e: ChangeEvent<HTMLInputElement>) => {
+			setEmail(e.target.value);
+			if (emailError) setEmailError("");
+		},
+		[emailError]
+	);
+
+	const handleSubmit = async (e: FormEvent) => {
+		e.preventDefault();
+		if (!validateForm()) return;
+
+		setIsLoading(true);
+		try {
+			// TODO: API 요청
+			console.log("이메일 제출:", email);
+		} catch (err) {
+			console.error("이메일 제출 실패", err);
+		} finally {
+			setIsLoading(false);
+		}
+	};
+
+	return {
+		email,
+		emailError,
+		isLoading,
+		handleEmailChange,
+		handleSubmit,
+	};
+};
+
+export default useResetPasswordForm;


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 한 줄 요약해주세요 -->
비밀번호 재설정 페이지를 추가했습니다.
---

## ✨ 주요 변경 사항
<!-- 어떤 기능을 구현/수정했는지 리스트로 작성해주세요 -->
- 비밀번호 재설정 페이지 추가했습니다.
- 

---

## 🖼️ 스크린샷 (선택)
<!-- UI 변경 사항이 있다면 스크린샷, GIF 등을 첨부해주세요 -->
|기본|이메일 형식 오류|정상적 이메일입력완료|
|--|--|--|
|<img width="1437" alt="스크린샷 2025-04-11 오후 11 56 10" src="https://github.com/user-attachments/assets/58883fa9-782f-4dbe-88f6-139841327ad6" />|<img width="1437" alt="스크린샷 2025-04-11 오후 11 56 21" src="https://github.com/user-attachments/assets/07864e64-b6cd-4f36-80a1-cefe840cfe53" />|<img width="1437" alt="스크린샷 2025-04-11 오후 11 56 38" src="https://github.com/user-attachments/assets/1716b08f-716b-4a15-ab15-5e698b537c31" />|


---

## ✅ 작업 체크리스트
- [ ] console.log / 불필요한 주석 제거
- [x] 변수명, 함수명 명확하게 작성
- [x] 동작 테스트 완료
- [x] 예외 케이스 고려
- [x] 반복 코드 함수로 분리

---

## 📂 테스트 방법
<!-- 어떤 페이지에서, 어떤 액션으로 테스트했는지 구체적으로 작성해주세요 -->

---

## 💬 기타 참고 사항
<!-- 코드 리뷰 시 중점적으로 봐줬으면 하는 부분이나 논의할 점, 고민한 내용 등 -->
비밀번호 재설정메일을 통해 재설정하게 된다면 이후는 어떻게 해야할지 고민입니다..
재설정이라면 메일에서 재설정 페이지에 들어갔을 때 어떻게 인증을 해야할지?
아니면 임시 비밀번호를 줘야하는지???
백엔드와 논의가 필요합니다!

피그마와 디자인이 좀 다릅니다.
다른 페이지와의 디자인 통일을 위해 인증메일전송 아래 로그인 돌아가기 버튼이 보이도록 했습니다.