### PR TITLE
비밀번호 재설정 폼 구현

### DIFF
--- a/src/app/update-password/page.tsx
+++ b/src/app/update-password/page.tsx
@@ -1,0 +1,10 @@
+import PasswordUpdateForm from "@/components/auth/PasswordUpdate/PasswordUpdateForm";
+import React from "react";
+
+export default function UpdatePasswordPage() {
+  return (
+    <div className="min-h-screen bg-gray flex items-center justify-center px-4">
+      <PasswordUpdateForm />
+    </div>
+  );
+};

--- a/src/app/update-password/page.tsx
+++ b/src/app/update-password/page.tsx
@@ -3,7 +3,7 @@ import React from "react";
 
 export default function UpdatePasswordPage() {
   return (
-    <div className="min-h-screen bg-gray flex items-center justify-center px-4">
+    <div className="flex justify-center items-center">
       <PasswordUpdateForm />
     </div>
   );

--- a/src/components/auth/PasswordReset/usePasswordResetForm.ts
+++ b/src/components/auth/PasswordReset/usePasswordResetForm.ts
@@ -1,8 +1,10 @@
 import { passwordReset } from "@/service/auth";
 import { validateEmail } from "@/utils/validate";
+import { useRouter } from "next/navigation";
 import { ChangeEvent, FormEvent, useCallback, useState } from "react";
 
 const useResetPasswordForm = () => {
+	const router = useRouter(); 
 	const [email, setEmail] = useState("");
 	const [emailError, setEmailError] = useState("");
 	const [isLoading, setIsLoading] = useState(false);
@@ -43,6 +45,7 @@ const useResetPasswordForm = () => {
 			}
 		} finally {
 			setIsLoading(false);
+			router.push("update-password");
 		}
 	};
 

--- a/src/components/auth/PasswordUpdate/PasswordUpdateForm.tsx
+++ b/src/components/auth/PasswordUpdate/PasswordUpdateForm.tsx
@@ -1,45 +1,54 @@
 "use client"; // 화면 마크업 //
-import React from "react";
+
+import React, { useState } from "react";
 import TextInput from "@/components/common/Input/TextInput";
-import { EvenIcon } from "@/components/common/Icons";
-import PasswordInput from "@/components/common/Input/PasswordInput";
 import BaseButton from "@/components/common/Button/BaseButton";
+import { EvenIcon } from "@/components/common/Icons";
 import Link from "next/link";
+import useResetPasswordForm from "../PasswordReset/usePasswordResetForm";
 
 const PasswordUpdateForm = () => {
-  return (
-    <div className="w-full max-w-[33rem] border border-white bg-gray900 p-6 mt-24">
-      <div className="flex justify-center items-center pt-8 pb-4 gap-4">
+  const [password, setPassword] = useState("");
+  const handlePasswordChange = () => {};
+
+  return(
+    <div className="w-full max-w-[28rem] border border-white mt-16">
+      <div className="flex justify-center items-center pt-8 pb-1 gap-4">
         <EvenIcon />
         <h1 className="text-4xl">even ide</h1>
       </div>
-      <div className="text-xl text-white text-center">
-        비밀번호 재설정
-      </div>
-      <p className="text-md text-white text-center pt-8 pb-10 gap-4">
-        새로운 비밀번호를 설정하세요. 
-      </p>
+      <div className="flex flex-col gap-5 px-6 sm:px-12 py-6">
+				<form  className="flex flex-col gap-6">
+					<h1 className="text-xl text-center mb-2">비밀번호 재설정</h1>
+					<h2 className="text-md text-center leading-loose mb-4">
+						새로운 비밀번호를 설정하세요.
+						<br />						
+					</h2>
 
-      <form className="w-full flex flex-col gap-8">
-        <PasswordInput
+          <TextInput
           placeholder="비밀번호를 입력하세요."
+          value={password}
+          onChange={handlePasswordChange}
           size="xl"
-          className="text-white placeholder-white"
-        />
-        <PasswordInput
+          />
+          <TextInput
           placeholder="비밀번호 확인"
+          value={password}
+          onChange={handlePasswordChange}          
           size="xl"
-          className="text-white placeholder-white"
-        />
-        <BaseButton type="submit" size="xl">
-          확인
-        </BaseButton>
-      </form>
+          />
 
-      <div className="flex justify-center mt-10 mb-8">
-        <Link href="/login" className="text-md text-violet-400 underline hover:opacity-80 transition"
-        >로그인으로 돌아가기
-        </Link>
+          <BaseButton type="submit" size="xl" >
+            확인
+          </BaseButton>
+          
+          <div className="flex justify-center text-sm text-violet-400 font-light mt-2 mb-4">
+            <Link href="/login" className="underline hover:opacity-80 transition"
+            >
+             로그인으로 돌아가기
+            </Link>
+          </div>
+        </form>            
       </div>
     </div>
   );

--- a/src/components/auth/PasswordUpdate/PasswordUpdateForm.tsx
+++ b/src/components/auth/PasswordUpdate/PasswordUpdateForm.tsx
@@ -1,49 +1,60 @@
-"use client"; // 화면 마크업 //
+"use client";
 
-import React, { useState } from "react";
-import TextInput from "@/components/common/Input/TextInput";
+import React, { ChangeEvent, useState } from "react";
 import BaseButton from "@/components/common/Button/BaseButton";
 import { EvenIcon } from "@/components/common/Icons";
 import Link from "next/link";
-import useResetPasswordForm from "../PasswordReset/usePasswordResetForm";
+import PasswordInput from "@/components/common/Input/PasswordInput";
 
 const PasswordUpdateForm = () => {
   const [password, setPassword] = useState("");
-  const handlePasswordChange = () => {};
+  const [confirmPassword, setConfirmPassword] = useState("");
+  
+  const handlePasswordChange = (
+    e: ChangeEvent<HTMLInputElement>
+  ) => {
+    setPassword(e.target.value);
+  };
 
-  return(
-    <div className="w-full max-w-[28rem] border border-white mt-16">
-      <div className="flex justify-center items-center pt-8 pb-1 gap-4">
+  const handleConfirmPasswordChange = (
+    e: ChangeEvent<HTMLInputElement>
+  ) => {
+    setConfirmPassword(e.target.value);
+  };
+
+  return (
+    <div className="w-full max-w-[30rem] border border-white mt-16">
+      <div className="flex justify-center items-center pt-8 pb-4 gap-4">
         <EvenIcon />
         <h1 className="text-4xl">even ide</h1>
       </div>
+
       <div className="flex flex-col gap-5 px-6 sm:px-12 py-6">
-				<form  className="flex flex-col gap-6">
-					<h1 className="text-xl text-center mb-2">비밀번호 재설정</h1>
-					<h2 className="text-md text-center leading-loose mb-4">
+				<form  className="flex flex-col gap-5">
+					<h1 className="text-xl text-white text-center">비밀번호 재설정</h1>
+					<h2 className="text-md text-white text-center leading-loose">
 						새로운 비밀번호를 설정하세요.
-						<br />						
 					</h2>
 
-          <TextInput
+          <PasswordInput
           placeholder="비밀번호를 입력하세요."
           value={password}
           onChange={handlePasswordChange}
           size="xl"
           />
-          <TextInput
+          <PasswordInput
           placeholder="비밀번호 확인"
-          value={password}
-          onChange={handlePasswordChange}          
+          value={confirmPassword}
+          onChange={handleConfirmPasswordChange}          
           size="xl"
           />
-
           <BaseButton type="submit" size="xl" >
             확인
-          </BaseButton>
-          
-          <div className="flex justify-center text-sm text-violet-400 font-light mt-2 mb-4">
-            <Link href="/login" className="underline hover:opacity-80 transition"
+          </BaseButton>        
+          <div className="flex justify-center text-sm text-gray200 font-light">
+            <Link
+              href="/login"
+              className="underline hover:opacity-80 transition"
             >
              로그인으로 돌아가기
             </Link>

--- a/src/components/auth/PasswordUpdate/PasswordUpdateForm.tsx
+++ b/src/components/auth/PasswordUpdate/PasswordUpdateForm.tsx
@@ -1,0 +1,48 @@
+"use client"; // 화면 마크업 //
+import React from "react";
+import TextInput from "@/components/common/Input/TextInput";
+import { EvenIcon } from "@/components/common/Icons";
+import PasswordInput from "@/components/common/Input/PasswordInput";
+import BaseButton from "@/components/common/Button/BaseButton";
+import Link from "next/link";
+
+const PasswordUpdateForm = () => {
+  return (
+    <div className="w-full max-w-[33rem] border border-white bg-gray900 p-6 mt-24">
+      <div className="flex justify-center items-center pt-8 pb-4 gap-4">
+        <EvenIcon />
+        <h1 className="text-4xl">even ide</h1>
+      </div>
+      <div className="text-xl text-white text-center">
+        비밀번호 재설정
+      </div>
+      <p className="text-md text-white text-center pt-8 pb-10 gap-4">
+        새로운 비밀번호를 설정하세요. 
+      </p>
+
+      <form className="w-full flex flex-col gap-8">
+        <PasswordInput
+          placeholder="비밀번호를 입력하세요."
+          size="xl"
+          className="text-white placeholder-white"
+        />
+        <PasswordInput
+          placeholder="비밀번호 확인"
+          size="xl"
+          className="text-white placeholder-white"
+        />
+        <BaseButton type="submit" size="xl">
+          확인
+        </BaseButton>
+      </form>
+
+      <div className="flex justify-center mt-10 mb-8">
+        <Link href="/login" className="text-md text-violet-400 underline hover:opacity-80 transition"
+        >로그인으로 돌아가기
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default PasswordUpdateForm;


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 한 줄 요약해주세요 -->
- 비밀번호 재설정 폼 구현
- 비밀번호 재설정 후 update-password 페이지로 리디렉션 추가
- UpdatePasswordPage 컴포넌트 추가 및 PasswordUpdateForm 적용
- 통일성을 위해 코드 수정
- 비밀번호 재설정 - 간격, 높이 수정
- Password 변경 페이지 레이아웃 수정과 필요없는 부분 삭제
---

## ✨ 주요 변경 사항
<!-- 어떤 기능을 구현/수정했는지 리스트로 작성해주세요 -->
- 비밀번호 재설정 폼 구현했습니다
- 비밀번호 입력 칸 생성
- 비밀번호 확인 칸 생성
- 확인 버튼 생성
- 로그인으로 돌아가기 클릭 시 로그인 홈 화면 이동
- 비밀번호 재설정 - 간격, 높이 수정
- Password 변경 페이지 레이아웃 수정과 필요없는 부분 삭제

---

## 🖼️ 스크린샷 (선택)
<!-- UI 변경 사항이 있다면 스크린샷, GIF 등을 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/d272ded7-5138-41c9-8436-865c6dd1747b)

---

## ✅ 작업 체크리스트
- [ ] console.log / 불필요한 주석 제거
- [ ] 변수명, 함수명 명확하게 작성
- [x] 동작 테스트 완료
- [ ] 예외 케이스 고려
- [ ] 반복 코드 함수로 분리

---

## 📂 테스트 방법
<!-- 어떤 페이지에서, 어떤 액션으로 테스트했는지 구체적으로 작성해주세요 -->
- **localhost:3000/update-password** 입력하면 비밀번호 재설정으로 이동합니다
- 로그인으로 돌아가기 클릭 시 로그인 홈화면으로 연결됩니다.
---

## 💬 기타 참고 사항
<!-- 코드 리뷰 시 중점적으로 봐줬으면 하는 부분이나 논의할 점, 고민한 내용 등 -->
- UI 관련된 부분은 성민님과 논의하여 수정했습니다!
