### PR TITLE
채팅 연결 실패시 예외처리 추가

### DIFF
--- a/src/components/editor/RightPanel/Chat/ChatInput.tsx
+++ b/src/components/editor/RightPanel/Chat/ChatInput.tsx
@@ -2,9 +2,14 @@ import { useChat } from "@/hooks/useChat";
 import MessageInput from "./common/MessageInput";
 
 const ChatInput = () => {
-	const { sendMessage } = useChat();
+	const { sendMessage, connected } = useChat();
 
-	return <MessageInput onSubmit={(message) => sendMessage(message)} />;
+	return (
+		<MessageInput
+			onSubmit={(message) => sendMessage(message)}
+			disabled={!connected}
+		/>
+	);
 };
 
 export default ChatInput;

--- a/src/components/editor/RightPanel/Chat/common/MessageInput.tsx
+++ b/src/components/editor/RightPanel/Chat/common/MessageInput.tsx
@@ -43,7 +43,8 @@ const MessageInput = ({ onSubmit, disabled }: MessageInputProps) => {
 				rounded-2xl resize-none placeholder:text-gray500 bg-gray900
 				focus:border-violet600 focus:shadow-violetGlow focus:outline-none focus:ring-0
 				"
-				placeholder="내용을 입력하세요"
+				placeholder={disabled ? "프로젝트를 선택하세요" : "내용을 입력하세요"}
+				disabled={disabled}
 				onKeyDown={(e) => {
 					if (e.key === "Enter" && !e.shiftKey && !isComposing) {
 						e.preventDefault();

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -3,6 +3,13 @@ import { useContext } from "react";
 
 export const useChat = () => {
 	const context = useContext(ChatContext);
-	if (!context) throw new Error("useChat must be used within a ChatProvider");
-	return context;
+	if (!context) {
+		return {
+			sendMessage: () => {
+				console.warn("ChatProvider가 없어서 메시지 전송이 비활성화됩니다.");
+			},
+			connected: false,
+		};
+	}
+	return { ...context, connected: true };
 };

--- a/src/providers/AppProviders.tsx
+++ b/src/providers/AppProviders.tsx
@@ -3,11 +3,14 @@
 import { SessionProvider } from "next-auth/react";
 import { ReactNode } from "react";
 import { ChatProvider } from "./ChatProvider";
+import { useProjectStore } from "@/stores/useProjectStore";
 
 export default function AppProviders({ children }: { children: ReactNode }) {
+	const projectId = useProjectStore((state) => state.projectId);
+
 	return (
 		<SessionProvider>
-			<ChatProvider>{children}</ChatProvider>
+			{projectId !== null ? <ChatProvider>{children}</ChatProvider> : children}
 		</SessionProvider>
 	);
 }

--- a/src/providers/ChatProvider.tsx
+++ b/src/providers/ChatProvider.tsx
@@ -67,7 +67,13 @@ export const ChatProvider = ({ children }: ChatProviderProps) => {
 			setMessages(historyData);
 
 			// WebSocket 연결
-			const socket = new SockJS(`${process.env.NEXT_PUBLIC_API_BASE_URL!}/ws`);
+			const socket = new SockJS(
+				`${process.env.NEXT_PUBLIC_API_BASE_URL!}/ws`,
+				[],
+				{
+					withCredentials: true,
+				}
+			);
 			const client = new Client({
 				webSocketFactory: () => socket,
 				reconnectDelay: 5000,


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 한 줄 요약해주세요 -->


채팅 연결을 실패했을 경우 예외처리를 추가했습니다.

---

## ✨ 주요 변경 사항
<!-- 어떤 기능을 구현/수정했는지 리스트로 작성해주세요 -->
- 웹소켓 채팅에 withCredentials 적용했습니다.
- 프로젝트 id가 선택되어있지 않을경우 기존에는 오류가 발생했지만 프로젝트 선택하라는 안내가 나오도록 수정했습니다.

---

## 🖼️ 스크린샷 (선택)
<!-- UI 변경 사항이 있다면 스크린샷, GIF 등을 첨부해주세요 -->
<img width="1081" alt="스크린샷 2025-04-24 오후 12 38 11" src="https://github.com/user-attachments/assets/50061e78-c5ba-46c9-99e3-9eba871a4dd8" />

---

## ✅ 작업 체크리스트
- [x] console.log / 불필요한 주석 제거
- [x] 변수명, 함수명 명확하게 작성
- [x] 동작 테스트 완료
- [x] 예외 케이스 고려
- [x] 반복 코드 함수로 분리

---

## 📂 테스트 방법
<!-- 어떤 페이지에서, 어떤 액션으로 테스트했는지 구체적으로 작성해주세요 -->


미로그인 상태 혹은 프로젝트가 생성되지 않은 상태에서 채팅버튼을 클릭하면 오류가 나지 않고 프로젝트 선택 placeholder가 뜨고 
로그인하면 채팅이 뜹니다! 

---

## 💬 기타 참고 사항
<!-- 코드 리뷰 시 중점적으로 봐줬으면 하는 부분이나 논의할 점, 고민한 내용 등 -->
