### PR TITLE
실시간 코드 편집 웹소켓 연결

### DIFF
--- a/src/providers/ChatProvider.tsx
+++ b/src/providers/ChatProvider.tsx
@@ -192,7 +192,7 @@ export const ChatProvider = ({ children }: ChatProviderProps) => {
 	}, [projectId, accessToken]);
 
 	useEffect(() => {
-		if (currentFileId) {
+		if (clientRef.current?.connected && currentFileId) {
 			subscribeToFile();
 		}
 	}, [currentFileId]);


### PR DESCRIPTION
## 📌 작업 개요
실시간 코드 편집 기능 추가

---

## ✨ 주요 변경 사항
실시간 코드 편집 기능
- 기존 웹소켓 활용(projectId)
- 파일 클릭시 주소에 fileId가 필요하므로 file 단위 구독 코드 추가했습니다. 

#### 1개의 웹소켓 연결, 서로 다른 topic 구독

항목|topic|상태
-- | -- | --
채팅 | /topic/project/{projectId} | 고정 구독 (project 기준)
코드 | /topic/project/{projectId}/file/{fileId} | 파일 이동 시마다 재구독 필요



---

## 🖼️ 스크린샷 (선택)
<!-- UI 변경사항이 있다면 스크린샷, GIF 등을 첨부해주세요 -->
![실시간 코드 편집](https://github.com/user-attachments/assets/02c420ae-a14b-454c-bbc2-46736bdfaa46)

---

## ✅ 작업 체크리스트
- [x] console.log / 불필요한 주석 제거
   -  확인용으로 일부러 넣어뒀는데 추후 작업시 필요 없을 것 같다면 삭제 바랍니다. 
- [x] 변수명, 함수명 명확하게 작성
- [x] 동작 테스트 완료
- [ ] 예외 케이스 고려
- [ ] 반복 코드 함수로 분리

---

## 📂 테스트 방법
에디터 페이지에서 크롬 창 2개 띄워놓고 실시간으로 반영되는 지 체크했습니다.

---

## 💬 기타 참고 사항
- diff(수정된 부분만 변경)로 하고 싶었는데.. 꽤 어려운 개념인 것 같아서 전체 코드 전송(디바운스 500)해서 반영되도록 했습니다.
    - 어려운 개념? 수정된 부분만 반영하려면 스페이스바.. 커서의 위치(column 값) 등이 고려되어야 하는 점.. 그래서 멘토님이 yjs rtc 방법을 알려주신 것 같습니다.
- 백엔드 단에서 1000건 정도 캐시로 저장하게 되는 걸로 기억합니다.
- 문제는.. 마지막으로 수정한 사람의 전체 내용으로 저장이 되어서 동시에 작성한다면 마지막 작성자의 코드로 반영이 되는 것 입니다.
- 현재 수정할 방법이 없어서.. 이렇게 진행해야 할 것 같습니다. 동작되는 것이.. 중요하다 생각됩니다 ㅠㅠ
- 커서 위치 하이라이트 하는 것도 구현은 해보았는데.. 썩 좋아보이지는 않아서 이번 PR에는 추가하지 않았습니다.
