### PR TITLE
코드 실행 버튼 색상 변경과 토스트 팝업과 로그인 유도 팝업 추가

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import "@/app/globals.css";
 import Layout from "@/components/layout/Layout";
 import AppProviders from "@/providers/AppProviders";
 import LoginModals from "@/components/modal/LoginModals";
+import ToastContainer from "@/components/common/Toast/ToastContainer";
 
 export const metadata: Metadata = {
 	title: "Even IDE",
@@ -23,6 +24,7 @@ export default function RootLayout({
 				<AppProviders>
 					<Layout>
 						{children}
+						<ToastContainer />
 						<LoginModals />
 					</Layout>
 				</AppProviders>

--- a/src/components/common/Toast/ToastContainer.tsx
+++ b/src/components/common/Toast/ToastContainer.tsx
@@ -15,7 +15,7 @@ export default function ToastContainer() {
   }, [toasts, removeToast]);
 
   return (
-    <div className="fixed top-12 left-1/2 transform -translate-x-1/2 z-50 flex flex-col gap-2">
+    <div className="fixed top-8 left-1/2 transform -translate-x-1/2 z-50 flex flex-col gap-2">
       {toasts.map((toast) => (
         <div
           key={toast.id}

--- a/src/components/common/Toast/ToastContainer.tsx
+++ b/src/components/common/Toast/ToastContainer.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useToastStore } from "@/stores/useToastStore";
+import { useEffect } from "react";
+
+export default function ToastContainer() {
+  const { toasts, removeToast } = useToastStore();
+
+  useEffect(() => {
+    if (toasts.length === 0) return;
+    const timer = setTimeout(() => {
+      removeToast(toasts[0].id);
+    }, 3000); // 토스트 팝업 등장 시간
+    return () => clearTimeout(timer);
+  }, [toasts, removeToast]);
+
+  return (
+    <div className="fixed top-12 left-1/2 transform -translate-x-1/2 z-50 flex flex-col gap-2">
+      {toasts.map((toast) => (
+        <div
+          key={toast.id}
+          className={`px-4 py-2 rounded shadow-md text-white ${
+            toast.type === "error" ? "bg-red-500" : toast.type === "success" ? "bg-green-500" : "bg-gray-700"
+          }`}
+        >
+          {toast.message}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/editor/RightPanel/Chat/ChatTitle.tsx
+++ b/src/components/editor/RightPanel/Chat/ChatTitle.tsx
@@ -1,38 +1,48 @@
 import IconButton from "@/components/common/Button/IconButton";
+import { Ellipsis } from "lucide-react";
 import {
-	ChatTransferIcon,
-	CloseIcon,
-	MinusCloseIcon,
+  ChatTransferIcon,
+  CloseIcon,
+  MinusCloseIcon,
 } from "@/components/common/Icons";
 import { useChatStore } from "@/stores/useChatStore";
 import { usePanelStore } from "@/stores/usePanelState";
+import { useLoginModalStore } from "@/stores/useLoginModalStore";
 import React from "react";
 
 const ChatTitle = () => {
-	const { viewMode, setViewMode } = useChatStore();
-	const { closePanel } = usePanelStore();
+  const { viewMode, setViewMode } = useChatStore();
+  const { closePanel } = usePanelStore();
+  const { open } = useLoginModalStore();
 
-	return (
-		<div className="p-4 text-md font-semibold text-white text-center flex justify-between items-center">
-			{viewMode === "panel" && <span>채팅</span>}
-			<div className="ml-auto">
-				<IconButton
-					icon={<ChatTransferIcon />}
-					size="sm"
-					label={viewMode === "modal" ? "패널로 보기" : "모달로 보기"}
-					transparent
-					onClick={() => setViewMode(viewMode === "modal" ? "panel" : "modal")}
-				/>
-				<IconButton
-					icon={viewMode === "modal" ? <CloseIcon /> : <MinusCloseIcon />}
-					size="sm"
-					label="닫기"
-					transparent
-					onClick={closePanel}
-				/>
-			</div>
-		</div>
-	);
+  return (
+    <div className="p-4 text-md font-semibold text-white text-center flex justify-between items-center">
+      {viewMode === "panel" && <span>채팅</span>}
+      <div className="ml-auto">
+        <IconButton
+          icon={<Ellipsis className="w-8 h-8" />}
+          size="sm"
+          label="로그인 모달"
+          transparent
+          onClick={open}
+        />
+        <IconButton
+          icon={<ChatTransferIcon />}
+          size="sm"
+          label={viewMode === "modal" ? "패널로 보기" : "모달로 보기"}
+          transparent
+          onClick={() => setViewMode(viewMode === "modal" ? "panel" : "modal")}
+        />
+        <IconButton
+          icon={viewMode === "modal" ? <CloseIcon /> : <MinusCloseIcon />}
+          size="sm"
+          label="닫기"
+          transparent
+          onClick={closePanel}
+        />
+      </div>
+    </div>
+  );
 };
 
 export default ChatTitle;

--- a/src/components/editor/RightPanel/Chat/ChatTitle.tsx
+++ b/src/components/editor/RightPanel/Chat/ChatTitle.tsx
@@ -8,24 +8,28 @@ import {
 import { useChatStore } from "@/stores/useChatStore";
 import { usePanelStore } from "@/stores/usePanelState";
 import { useLoginModalStore } from "@/stores/useLoginModalStore";
+import { useAuthStore } from "@/stores/useAuthStore";
 import React from "react";
 
 const ChatTitle = () => {
   const { viewMode, setViewMode } = useChatStore();
   const { closePanel } = usePanelStore();
   const { open } = useLoginModalStore();
+  const { isLoggedIn } = useAuthStore();
 
   return (
     <div className="p-4 text-md font-semibold text-white text-center flex justify-between items-center">
       {viewMode === "panel" && <span>채팅</span>}
       <div className="ml-auto">
-        <IconButton
-          icon={<Ellipsis className="w-8 h-8" />}
-          size="sm"
-          label="로그인 모달"
-          transparent
-          onClick={open}
-        />
+        {!isLoggedIn && (
+          <IconButton
+            icon={<Ellipsis className="w-8 h-8" />}
+            size="sm"
+            label="로그인 모달"
+            transparent
+            onClick={open}
+          />
+        )}
         <IconButton
           icon={<ChatTransferIcon />}
           size="sm"

--- a/src/components/editor/RunButton.tsx
+++ b/src/components/editor/RunButton.tsx
@@ -42,7 +42,7 @@ export default function RunButton({ terminalRef }: RunButtonProps) {
   return (
     <button
       onClick={handleRun}
-      className="w-[100px] px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded font-semibold shadow-md transition duration-150"
+      className="w-[100px] px-4 py-2 bg-blue500 hover:bg-violet600 text-white rounded font-semibold shadow-md transition duration-150"
     >
       실행 ▶
     </button>

--- a/src/components/layout/Sidebar/Sidebar.tsx
+++ b/src/components/layout/Sidebar/Sidebar.tsx
@@ -8,6 +8,7 @@ import { useProjectStore } from "@/stores/useProjectStore";
 import { createProject } from "@/service/project";
 import { createFile, deleteFileById, updateFileName } from "@/service/file";
 import { getAuthCookie } from "@/lib/cookie";
+import { useToastStore } from "@/stores/useToastStore";
 import { deleteProject } from "@/service/project";
 import { usePathname } from "next/navigation";
 import {
@@ -43,10 +44,11 @@ export default function Sidebar() {
   const token = getAuthCookie().token;
   const pathname = usePathname();
   const isInProjectPage = pathname.startsWith("/project/");
+  const { addToast } = useToastStore();
 
   // 파일 추가 (임시 생성 → 이름 입력 후 서버로 생성)
   const handleAddFile = async () => {
-    // 프로젝트 페이지 프로젝트 선택 없이 파일 추가 가능
+    // 프로젝트 페이지 프로젝트 선택 없이 파일 추가 가능
     if (isInProjectPage) {
       const project = projects[0]; // 상태에 저장된 하나의 프로젝트
       if (!project || !token) return;
@@ -59,7 +61,7 @@ export default function Sidebar() {
 
     // 에디터 페이지는 프로젝트 선택 필수
     if (!selectedProjectId) {
-      alert("먼저 프로젝트를 선택해주세요.");
+      addToast("먼저 프로젝트를 선택해주세요.", "error");
       return;
     }
 
@@ -100,7 +102,7 @@ export default function Sidebar() {
         setEditingFileId(null);
       }
     } catch (err) {
-      alert("파일 생성 실패");
+      addToast("파일 생성 실패", "error");
       console.error(err);
     }
   };
@@ -127,7 +129,7 @@ export default function Sidebar() {
 
     // 로그인 여부 확인
     if (!token) {
-      alert("로그인이 필요합니다.");
+      addToast("로그인이 필요합니다.", "error");
       setIsSubmitting(false);
       return;
     }
@@ -166,7 +168,7 @@ export default function Sidebar() {
     }
 
     if (!targetUUID) {
-      alert("이동할 프로젝트를 찾을 수 없습니다.");
+      addToast("이동할 프로젝트를 찾을 수 없습니다.", "error");
       return;
     }
 
@@ -189,7 +191,7 @@ export default function Sidebar() {
       console.log("📂 all projects:", projects);
 
       if (!file || numericProjectId === undefined || !token) {
-        alert("파일 정보를 찾을 수 없습니다.");
+        addToast("파일 정보를 찾을 수 없습니다.", "error");
         return;
       }
 
@@ -198,7 +200,7 @@ export default function Sidebar() {
         deleteFile(file.id); // Zustand 상태 삭제
       } catch (err) {
         console.error("파일 삭제 실패:", err);
-        alert("파일 삭제 중 오류가 발생했습니다.");
+        addToast("파일 삭제 중 오류가 발생했습니다.", "error");
       }
 
       return;
@@ -211,7 +213,7 @@ export default function Sidebar() {
 
       const project = projects.find((p) => p.id === selectedProjectId);
       if (!project || !token) {
-        alert("프로젝트 정보를 찾을 수 없습니다.");
+        addToast("프로젝트 정보를 찾을 수 없습니다.", "error");
         return;
       }
 
@@ -221,13 +223,13 @@ export default function Sidebar() {
         setSelectedProjectId(null); // 선택 해제
       } catch (err) {
         console.error("프로젝트 삭제 실패:", err);
-        alert("프로젝트 삭제 중 오류가 발생했습니다.");
+        addToast("프로젝트 삭제 중 오류가 발생했습니다.", "error");
       }
 
       return;
     }
 
-    alert("삭제할 항목을 선택해주세요.");
+    addToast("삭제할 항목을 선택해주세요.", "error");
   };
 
   return (

--- a/src/stores/useToastStore.ts
+++ b/src/stores/useToastStore.ts
@@ -1,0 +1,28 @@
+import { create } from "zustand";
+
+interface Toast {
+  id: number;
+  message: string;
+  type: "success" | "error" | "info"; // 타입별 스타일
+}
+
+interface ToastState {
+  toasts: Toast[];
+  addToast: (message: string, type?: Toast["type"]) => void;
+  removeToast: (id: number) => void;
+}
+
+export const useToastStore = create<ToastState>((set) => ({
+  toasts: [],
+  addToast: (message, type = "info") =>
+    set((state) => ({
+      toasts: [
+        ...state.toasts,
+        { id: Date.now(), message, type },
+      ],
+    })),
+  removeToast: (id) =>
+    set((state) => ({
+      toasts: state.toasts.filter((toast) => toast.id !== id),
+    })),
+}));


### PR DESCRIPTION
## 📌 작업 개요
- 코드 실행 버튼 색상 변경과 토스트 팝업과 로그인 유도 팝업 추가

---

## ✨ 주요 변경 사항
- 토스트 팝업 컴포넌트와 zustand 를 구현 및 추가했습니다
- 프로젝트와 파일 추가, 조회, 삭제 시 등장하는 오류 alert 을 토스트 팝업으로 바꿔봤습니다 !
- 코드 실행 버튼 색상을 변경했습니다 (blue-500 -> blue500)
- 비로그인 시 채팅창 상단에 미트볼 버튼이 등장하고 클릭 시 로그인 유도 모달이 등장합니다

---

## 🖼️ 스크린샷 (선택)
<img width="1033" alt="image" src="https://github.com/user-attachments/assets/ea856c00-19bc-48ad-be75-51288f14b564" />
< 토스트 팝업 위치와 디자인 ><br>
<img width="315" alt="image" src="https://github.com/user-attachments/assets/e98351e9-ee2d-4fb7-a506-37037c6eff12" /><br>
< error 설정 ><br>
<img width="290" alt="image" src="https://github.com/user-attachments/assets/6a38b615-8d14-4caf-b9d1-781f8b4f6280" /><br>
< success 설정 ><br>
<img width="305" alt="image" src="https://github.com/user-attachments/assets/0a776108-cbc1-4af5-a9a7-9ade8ddb4ed2" /><br>
< info 설정 ><br>
<img width="323" alt="image" src="https://github.com/user-attachments/assets/82f3d341-0f51-4bb6-ba91-faa26203aab3" /><br>
< 실행 버튼 ><br>
<img width="362" alt="image" src="https://github.com/user-attachments/assets/05dd5328-4ae5-49a4-bdd6-eebbd318c3b8" /><br>
< 비로그인 시 미트볼 버튼 등장 >

---

## ✅ 작업 체크리스트
- [ ] console.log / 불필요한 주석 제거
- [x] 변수명, 함수명 명확하게 작성
- [x] 동작 테스트 완료
- [ ] 예외 케이스 고려
- [ ] 반복 코드 함수로 분리

---

## 📂 테스트 방법
npm run build 통
작동 테스트 완료

---

## 💬 기타 참고 사항
토스트 팝업 zustand 와 컴포넌트를 추가해봤습니다
임시로 사이드 바에서만 수정해봤는데 디자인이 괜찮은지 확인 부탁드리구
디자인이나 등장 위치(현재 가운데 상단)에 대해 얼마든지 의견 주시면 최대한 반영해보겠습니다 !

토스트 팝업을 사용하실 분은
import { useToastStore } from "@/stores/useToastStore"; 을 진행하신 후
const { addToast } = useToastStore(); 를 선언한 후 원하시는 곳에 
addToast("먼저 프로젝트를 선택해주세요.", "error"); 형식으로 alert 을 대체하거나 추가하시면 됩니다

코드 실행 버튼도 일단 색상을 변경해봤는데, 제일 처음에 만들어놨던 디자인이라
얼마든지 디자인 변경에 대한 의견 주시면 역시 최대한 반영해보겠습니다 !