### PR TITLE
프로젝트 페이지 별도 파비콘과 타이틀 적용

### DIFF
--- a/src/app/project/[uuid]/layout.tsx
+++ b/src/app/project/[uuid]/layout.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Even IDE - Project",
+  description: "Project workspace on Even IDE",
+  icons: {
+    icon: `/favicon.svg`,
+  },
+};
+
+export default function ProjectLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}


### PR DESCRIPTION
## 📌 작업 개요
프로젝트 페이지 별도 파비콘과 타이틀 적용

---

## ✨ 주요 변경 사항
- 프로젝트 페이지 별도 파비콘과 타이틀 적용 

---

## 🖼️ 스크린샷 (선택)
<img width="246" alt="image" src="https://github.com/user-attachments/assets/aac215e2-b0cc-4b60-a077-26539c8403e2" />

---

## ✅ 작업 체크리스트
- [ ] console.log / 불필요한 주석 제거
- [ ] 변수명, 함수명 명확하게 작성
- [ ] 동작 테스트 완료
- [ ] 예외 케이스 고려
- [ ] 반복 코드 함수로 분리

---

## 📂 테스트 방법
<!-- 어떤 페이지에서, 어떤 액션으로 테스트했는지 구체적으로 작성해주세요 -->

---

## 💬 기타 참고 사항
아하 이게 Next.js 공식 문서에도 나온 이슈라고 하네요
동적 라우트([uuid]) 안에서는 metadata 상속이 부정확하게 동작할 때가 있어서 다시 적용을 해줘야하는데
방법은 layout.tsx 를 해당 페이지에 별도로 만들어서 적용하면 된다고 합니다 !

title: "Even IDE - Project",
description: "Project workspace on Even IDE",

GPT가 이렇게 변경하는 걸 추천했는데, 괜찮은 것 같아서 임의 적용해봤습니다
기존과 동일하게 다시 바꿔도 되니 편하게 말씀 주세요 !
